### PR TITLE
MOR 766 - add get in touch cta to docs developer api page

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "site": "morgen-cw-docs",
+    "site": "morgen-docs",
     "public": "out",
     "cleanUrls": true,
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "export": "next build && next export",
-    "deploy": "npm run export && firebase deploy --only hosting:morgen-cw-docs"
+    "deploy": "npm run export && firebase deploy --only hosting:morgen-docs"
   },
   "author": "Morgen AG",
   "license": "UNLICENSED",

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,5 +1,13 @@
+import { Callout, Link } from "nextra-theme-docs";
+
 # Introduction
 Morgen API allows developers to build features that interact with calendars hosted on different providers, including Google, Microsoft, Apple and other CalDAV providers.
+
+<Callout type="info" emoji="🚀">
+  Thinking of integrating Morgen into <b>your product or service</b>?
+  <Link href="mailto:connect@morgen.so?body=Hi, I'm interested in integrating the Morgen API into my product... (please provide details)">Contact us</Link>
+  to tell us more about what you need and get <b>early access</b>.
+</Callout>
 
 ## What can I do?
 **Morgen API** allows you to:


### PR DESCRIPTION
<img width="871" alt="Screenshot 2023-10-09 at 11 59 08" src="https://github.com/morgen-so/morgen-dev-docs/assets/6750344/d6cdee45-be3a-4e63-936e-e97ada52e6d6">
