### PR TITLE
update documentation to reflect morgen v4 changes

### DIFF
--- a/pages/events.mdx
+++ b/pages/events.mdx
@@ -74,6 +74,11 @@ Here is an example response for the `/events/list` endpoint described above:
         // 3rd-party ID for the base event in the recurrence
         "baseEventId": "AAkALgAAAAAAHYQDEapmEc2by...",
 
+        // For recurring event instances: Morgen ID of the master recurring event
+        "masterEventId": "WyI2NDBhNjJjOWFhNWI3ZTA2Y2Y0MjAwMDA...",
+        // For recurring event instances: 3rd-party ID of the master recurring event
+        "masterBaseEventId": "AAkALgAAAAAAHYQDEapmEc2by...",
+
         "created": "2023-02-28T11:50:57",
         "updated": "2023-02-28T17:56:44",
 
@@ -111,9 +116,9 @@ Here is an example response for the `/events/list` endpoint described above:
         },
 
         "participants": {
-          // Map of pariticpant IDs to participants.
-          // The key is the base64 encoded participant email address.
-          "ZGF2aWRAbW9yZ2Vu0000": {
+          // Map of participant IDs to participants.
+          // The key can be the participant's email address or an internal ID.
+          "doe@morgen.so": {
             "@type": "Participant",
             "name": "John Doe",
 
@@ -152,8 +157,9 @@ Here is an example response for the `/events/list` endpoint described above:
 
 
         "alerts": {
-          // Map of alert IDs to alerts. Key can be any string, as long as it is unique.
-          "1": {
+          // Map of alert IDs to alerts.
+          // Alert IDs are base64-encoded: btoa(JSON.stringify({ a: action, to: offset }))
+          "eyJhIjoiZGlzcGxheSIsInRvIjoiLVBUMTVNIn0=": {
             "@type": "Alert",
             "trigger": {
               "@type": "OffsetTrigger",
@@ -166,6 +172,23 @@ Here is an example response for the `/events/list` endpoint described above:
           },
           ...
         },
+
+        // Use default calendar alerts instead of custom alerts
+        "useDefaultAlerts": false,
+
+        // Recurrence rules for recurring events
+        "recurrenceRules": [
+          {
+            "@type": "RecurrenceRule",
+            "frequency": "weekly",
+            "interval": 1,
+            "byDay": [{ "@type": "NDay", "day": "mo" }]
+          }
+        ],
+
+        // Google Calendar specific fields
+        "google.com:colorId": "5", // Writable: Google's event color ID (1-11)
+        "google.com:hangoutLink": "https://meet.google.com/abc-defg-hij",
       },
 
       // Derived, read-only fields.
@@ -206,13 +229,46 @@ Morgen returns some additional fields for convenience and to provide more inform
 - `accountId`: The ID of the account the event belongs to.
 - `calendarId`: The ID of the calendar the event belongs to.
 - `baseEventId`: The provider ID of the base event the event belongs to. This is the ID of the recurring event for recurring events, and the ID of the event itself for non-recurring events.
+- `masterEventId`: The Morgen ID of the master recurring event (for recurring event instances only). Can be used with `recurrenceId` to identify and update specific instances.
 - `masterBaseEventId`: The provider ID of the master base event the event belongs to. This is the ID of the master recurring event for recurring events, and will not be returned for non-recurring events.
-- `morgen.so:derived`: An object containing useful field derived from other event information. Read-only.
-- `morgen.so:metadata`: An objects containing Morgen-specific metadata, such as the event category and the link to a task.
+- `morgen.so:derived`: An object containing useful fields derived from other event information. Read-only.
+- `morgen.so:metadata`: An object containing Morgen-specific metadata, such as the event category and the link to a task.
+- `morgen.so:requestVirtualRoom`: Writable field to request creation of a virtual meeting room (`"default"` | `"googleMeet"` | `"microsoftTeams"`).
+- `useDefaultAlerts`: Boolean flag to use the calendar's default alert settings instead of custom alerts.
 
 <Callout type="warning" emoji="⚠️">
   Additional fields might be added in the future. If you are storing the event
   in your database, please make sure to ignore unknown fields.
+</Callout>
+
+#### Google Calendar Color ID
+
+For Google Calendar events, you can set the event color using the `google.com:colorId` field:
+
+| Field | Type | Access | Description |
+| :---- | :--- | :----- | :---------- |
+| `google.com:colorId` | String | Read/Write | Google's event color ID. Valid values are "1" through "11", each representing a different color in Google Calendar's color palette. |
+
+<Callout type="info" emoji="💡">
+  The `google.com:colorId` field is only available for Google Calendar events. Valid values are "1" through "11". See the [Google Calendar Colors API documentation](https://developers.google.com/workspace/calendar/api/v3/reference/colors/get) for details on what each color ID represents.
+</Callout>
+
+**Example**: Setting a Google Calendar event color when creating an event
+```json
+{
+  "accountId": "640a62c9aa5b7e06cf420000",
+  "calendarId": "WyI2NDBhNjJjOW...",
+  "title": "Team Meeting",
+  "start": "2023-03-15T14:00:00",
+  "duration": "PT1H",
+  "timeZone": "America/New_York",
+  "showWithoutTime": false,
+  "google.com:colorId": "5"
+}
+```
+
+<Callout type="warning" emoji="⚠️">
+  This field only works for Google Calendar accounts. Attempting to set `google.com:colorId` on non-Google calendars (Office 365, iCloud, CalDAV, etc.) will have no effect.
 </Callout>
 
 ## Create an event
@@ -247,7 +303,28 @@ The event is created in the calendar of the account identified by the `accountId
     </Tabs.Tab>
 </Tabs>
 
-The fields `accountId` and `calendarId` are mandatory. Other fields of an event are described in the [JSCalendar standard](https://datatracker.ietf.org/doc/rfc8984/).
+### Request Body Fields
+
+| Field | Type | Required | Description |
+| :---- | :--- | :------- | :---------- |
+| `accountId` | String | Yes | The ID of the account to create the event in. |
+| `calendarId` | String | Yes | The ID of the calendar to create the event in. |
+| `title` | String | Yes | The title/summary of the event. |
+| `start` | String | Yes | Start time in LocalDateTime format (e.g., `2023-03-01T10:15:00`). |
+| `duration` | String | Yes | Duration in ISO 8601 format (e.g., `PT1H` for 1 hour, `PT30M` for 30 minutes). |
+| `timeZone` | String or null | Yes | IANA timezone (e.g., `Europe/Paris`). Use `null` for floating events (no timezone). |
+| `showWithoutTime` | Boolean | Yes | `true` for all-day events, `false` for timed events. |
+| `description` | String | No | Event description. Can be plain text or HTML (specify with `descriptionContentType`). |
+| `descriptionContentType` | String | No | Either `text/plain` or `text/html`. Default: `text/plain`. |
+| `locations` | Object | No | Map of location IDs to location objects. See [JSCalendar standard](https://datatracker.ietf.org/doc/rfc8984/). |
+| `participants` | Object | No | Map of participant IDs to participant objects. The key should be the base64-encoded email address. |
+| `alerts` | Object | No | Map of alert IDs to alert objects. See Alert structure above. Cannot be used with `useDefaultAlerts: true`. |
+| `useDefaultAlerts` | Boolean | No | If `true`, use the calendar's default alert settings. Cannot be used together with `alerts`. |
+| `privacy` | String | No | `public`, `private`, or `secret`. Default: `public`. |
+| `freeBusyStatus` | String | No | `free` or `busy`. Default: `busy`. |
+| `recurrenceRules` | Array | No | Array of recurrence rule objects for recurring events. |
+
+Other fields from the [JSCalendar standard](https://datatracker.ietf.org/doc/rfc8984/) are also supported.
 
 ## Update an event
 
@@ -283,9 +360,31 @@ The following endpoint can be used to update an event in a given calendar.
 | Parameter          | Type  | Default  | Required | Description                                                                                                                                                                                                                              |
 | :----------------- | :---- | :------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `seriesUpdateMode` | Query | `single` | No       | Defines how to update recurring events. Possible values are: `all` (update all events), `future` (update this and future occurrences), `single` (update this event only, default). This parameter has no effect on non-recurring events. |
-| `id`               | Body  | -        | Yes      | The ID of the event to update.                                                                                                                                                                                                           |
-| `accountId`        | Body  | -        | Yes      | The ID of the account the event belongs to.                                                                                                                                                                                              |
-| `calendarId`       | Body  | -        | Yes      | The ID of the calendar the event belongs to.                                                                                                                                                                                             |
+
+### Request Body Fields
+
+| Field | Type | Required | Description |
+| :---- | :--- | :------- | :---------- |
+| `id` | String | Yes* | The Morgen ID of the event to update. *Can be omitted if `masterEventId` and `recurrenceId` are provided (see below). |
+| `accountId` | String | Yes | The ID of the account the event belongs to. |
+| `calendarId` | String | Yes | The ID of the calendar the event belongs to. |
+| `masterEventId` | String | No | For recurring event instances: The Morgen ID of the master recurring event. Must be provided with `recurrenceId` if `id` is not provided. |
+| `recurrenceId` | String | No | For recurring event instances: The LocalDateTime identifying this instance (e.g., `2023-08-29T16:00:00`). Must be provided with `masterEventId` if `id` is not provided. |
+| `recurrenceIdTimeZone` | String | No | Optional timezone for the `recurrenceId` (not required for all-day events). |
+
+All other event fields are optional for updates. Only include the fields you want to change.
+
+<Callout type="info" emoji="💡">
+  When updating timing fields (`start`, `duration`, `timeZone`, `showWithoutTime`), you must provide all four together. For example, to change only the start time, you must also include the current values for `duration`, `timeZone`, and `showWithoutTime`.
+</Callout>
+
+<Callout type="info" emoji="💡">
+  **Updating Recurring Event Instances**: You can update a specific instance of a recurring event in two ways:
+  1. Using the instance's direct `id` (if you have it)
+  2. Using `masterEventId` + `recurrenceId` (the LocalDateTime of the instance)
+
+  Example: To update the August 29th instance of a recurring meeting, you can provide `masterEventId` (the ID of the recurring series) and `recurrenceId: "2023-08-29T16:00:00"` instead of the instance's direct ID.
+</Callout>
 
 Other fields of an event are described in the [JSCalendar standard](https://datatracker.ietf.org/doc/rfc8984/).
 
@@ -337,6 +436,109 @@ Here is an example of a request to update an event title, while leaving all othe
         ```
     </Tabs.Tab>
 </Tabs>
+
+### Special cases
+
+#### Updating Alerts
+
+Alerts can be updated for Google Calendar events using the `/events/update` endpoint:
+
+**Add a new alert**: Include the alert with its properties. The alert ID must be calculated using the encoding formula below:
+
+Alert ID = base64(JSON.stringify({ "a": action, "to": offset }, with keys sorted alphabetically))
+
+You can use standard base64 encoding libraries in your language of choice (e.g., `btoa()` in JavaScript, `base64` module in Python, `Buffer.from().toString('base64')` in Node.js).
+
+Example calculation for an alert with `offset: "-PT30M"` and `action: "display"`:
+```javascript
+// JavaScript example
+const alertId = btoa(JSON.stringify({ a: "display", to: "-PT30M" }));
+// Result: "eyJhIjoiZGlzcGxheSIsInRvIjoiLVBUMzBNIn0="
+```
+
+```json
+{
+  "accountId": "640a62c9aa5b7e06cf420000",
+  "calendarId": "WyI2NDBhNjJjOW...",
+  "id": "WyJhbmNvbmEubXJjQGdtYWl",
+  "alerts": {
+    "eyJhIjoiZGlzcGxheSIsInRvIjoiLVBUMzBNIn0=": {
+      "@type": "Alert",
+      "trigger": {
+        "@type": "OffsetTrigger",
+        "offset": "-PT30M",
+        "relativeTo": "start"
+      },
+      "action": "display"
+    }
+  }
+}
+```
+
+**Remove an alert**: Calculate the alert ID using the same formula above, then set that alert to `null`:
+```json
+{
+  "accountId": "640a62c9aa5b7e06cf420000",
+  "calendarId": "WyI2NDBhNjJjOW...",
+  "id": "WyJhbmNvbmEubXJjQGdtYWl",
+  "alerts": {
+    "eyJhIjoiZGlzcGxheSIsInRvIjoiLVBUMzBNIn0=": null
+  }
+}
+```
+
+**Use default calendar alerts**: Set `useDefaultAlerts` to `true` to use the calendar's default alert settings instead of custom alerts:
+```json
+{
+  "accountId": "640a62c9aa5b7e06cf420000",
+  "calendarId": "WyI2NDBhNjJjOW...",
+  "id": "WyJhbmNvbmEubXJjQGdtYWl",
+  "useDefaultAlerts": true
+}
+```
+
+When `useDefaultAlerts` is `true`, the `alerts` field should not be set, as the calendar's default alerts will be used instead.
+
+#### Updating Participants
+
+Participants can be updated using the `/events/update` endpoint with patch operations:
+
+**Add a new participant**: Include the participant with their details. The participant ID can be the participant's email address:
+```json
+{
+  "accountId": "640a62c9aa5b7e06cf420000",
+  "calendarId": "WyI2NDBhNjJjOW...",
+  "id": "WyJhbmNvbmEubXJjQGdtYWl",
+  "participants": {
+    "new@example.com": {
+      "@type": "Participant",
+      "name": "New Attendee",
+      "email": "new@example.com",
+      "roles": {
+        "attendee": true
+      },
+      "participationStatus": "needs-action"
+    }
+  }
+}
+```
+
+<Callout type="info" emoji="💡">
+  **Participant updates are patch operations**: When you update participants, existing participants not mentioned remain unchanged. Only participants you explicitly include (to add/modify) or set to `null` (to remove) are affected.
+</Callout>
+
+**Remove a participant**: Set the participant to `null` using their email address:
+```json
+{
+  "accountId": "640a62c9aa5b7e06cf420000",
+  "calendarId": "WyI2NDBhNjJjOW...",
+  "id": "WyJhbmNvbmEubXJjQGdtYWl",
+  "participants": {
+    "existing@example.com": null
+  }
+}
+```
+
 
 ## Request the creation of a virtual meeting room
 
@@ -430,3 +632,78 @@ The following endpoint can be used to update an event in a given calendar.
 <Callout type="warning" emoji="⚠️">
   Currently `seriesUpdateMode` only supports the default value (`single`).
 </Callout>
+
+## Common Validation Errors
+
+When creating or updating events, you may encounter validation errors. Here are the most common errors and how to resolve them:
+
+### Missing Required Timing Fields
+
+**Error Message**:
+```
+Properties `start`, `duration`, `timeZone` and `showWithoutTime` must be provided together. `timeZone` can be `null` to indicate floating events.
+```
+
+**Cause**: You provided some but not all of the required timing fields.
+
+**Solution**: Always provide all four fields together: `start`, `duration`, `timeZone`, and `showWithoutTime`.
+
+**Example**:
+```json
+{
+  "start": "2023-03-01T10:15:00",
+  "duration": "PT1H",
+  "timeZone": "Europe/Berlin",
+  "showWithoutTime": false
+}
+```
+
+---
+
+### Invalid Timezone
+
+**Error Message**:
+```
+Event 'timeZone' should be a valid IANA time zone (e.g. Europe/Paris)
+```
+
+**Cause**: The provided timezone is not a valid IANA timezone identifier.
+
+**Solution**: Use valid IANA timezone names. See the [IANA Time Zone Database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+**Valid Examples**: `America/New_York`, `Europe/London`, `Asia/Tokyo`
+**Invalid Examples**: `EST`, `PST`, `GMT+1`
+
+---
+
+### Invalid Duration Format
+
+**Error Message**:
+```
+Event `duration` should be a valid ISO8601 duration (e.g. P1D)
+```
+
+**Cause**: The duration is not in valid ISO 8601 format.
+
+**Solution**: Use ISO 8601 duration format: `PT[hours]H[minutes]M` or `P[days]D`
+
+**Valid Examples**:
+- `PT1H` - 1 hour
+- `PT30M` - 30 minutes
+- `PT1H30M` - 1 hour 30 minutes
+- `P1D` - 1 day
+
+---
+
+### Event Identification Error
+
+**Error Message**:
+```
+Event must have either 'id' or both 'masterEventId' and 'recurrenceId'
+```
+
+**Cause**: When updating/deleting an event, you didn't provide a valid way to identify it.
+
+**Solution**: Provide either:
+1. The event's direct `id`, OR
+2. Both `masterEventId` and `recurrenceId` (for recurring event instances)


### PR DESCRIPTION
## Changes
- Updated example response to add more relevant fields
- Add new patch mentions for some fields (alert, participant)
- Mention alternative id for recurring events
- Mention some of the validation we have for event body
