### PR TITLE
Only add new task api and rate limits pages

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch"
+    ]
+  }
+}

--- a/pages/rate-limits.mdx
+++ b/pages/rate-limits.mdx
@@ -1,0 +1,59 @@
+import { Callout } from "nextra/components";
+
+# Rate Limits
+
+The Morgen API enforces rate limits to ensure fair usage and system stability. Rate limits are applied per user and vary based on authentication method.
+
+## Rate Limit Values
+
+| Authentication | Limit | Window |
+| :------------- | :---- | :----- |
+| API Key | 250 points | 15 minutes |
+| JWT Token | 300 requests | 15 minutes |
+
+## Points System (API Key)
+
+When using API Key authentication, requests consume points based on the operation:
+
+| Operation | Points Cost |
+| :-------- | :---------- |
+| Single resource operations (get, create, update, delete) | 1 point |
+| List operations | `min(limit, 100)` points |
+
+For list operations, the points cost is based on the `limit` query parameter, capped at 100 points per request.
+
+<Callout type="info" emoji="💡">
+  To optimize your rate limit usage, use the `updatedAfter` parameter to fetch only recently changed resources instead of listing all items.
+</Callout>
+
+## Rate Limit Headers
+
+Every API response includes headers to help you track your rate limit usage:
+
+| Header | Description |
+| :----- | :---------- |
+| `RateLimit-Limit` | Maximum points/requests allowed in the current window |
+| `RateLimit-Remaining` | Points/requests remaining in the current window |
+| `RateLimit-Reset` | Seconds until the rate limit window resets |
+| `Retry-After` | Total seconds to wait before retrying, up to 900 seconds (15 minutes) (only present on 429 responses) |
+
+### Example Headers
+
+```
+RateLimit-Limit: 250
+RateLimit-Remaining: 150
+RateLimit-Reset: 459
+```
+
+## Handling Rate Limits
+
+When you exceed the rate limit, the API returns a `429 Too Many Requests` response. The response includes a `Retry-After` header indicating how long to wait before retrying.
+
+### Best Practices
+
+- Monitor the `RateLimit-Remaining` header to avoid hitting limits
+- Implement exponential backoff when receiving 429 responses
+- Use `updatedAfter` filters to reduce the number of items returned
+- Cache responses where appropriate to reduce API calls
+- For list operations, request only what you need using the `limit` parameter
+

--- a/pages/tasks.mdx
+++ b/pages/tasks.mdx
@@ -36,11 +36,11 @@ Returns a list of tasks, optionally filtered by update time.
 
 | Parameter      | Type  | Default | Required | Description                                                    |
 | :------------- | :---- | :------ | :------- | :------------------------------------------------------------- |
-| `limit`        | Query | -       | No       | Maximum number of tasks to return.                             |
+| `limit`        | Query | 100     | No       | Maximum number of tasks to return (max 100).                   |
 | `updatedAfter` | Query | -       | No       | Only return tasks updated after this ISO 8601 datetime.        |
 
 <Callout type="warning" emoji="⚠️">
-  The Tasks API is primarily designed for creating tasks in Morgen from unsupported integrations.
+  The Tasks API is primarily designed for creating tasks in Morgen from unsupported integrations using apps like Zapier.
   Listing tasks has a higher rate limit cost based on the `limit` parameter.
   See [Rate Limits](/rate-limits) for details.
 </Callout>
@@ -515,60 +515,6 @@ Mark a completed task as not completed.
 | :---- | :--- | :------- | :---------- |
 | `id` | String | Yes | The Morgen ID of the task to reopen. |
 | `occurrenceStart` | String | No | For recurring tasks: ISO 8601 datetime of the specific occurrence to reopen. |
-
-### Response
-
-Returns HTTP 204 No Content on success.
-
-## Create a time tracking interval
-
-Record time spent working on a task.
-
-<Tabs items={['API Key', 'JWT Token']}>
-    <Tabs.Tab>
-        ```js
-        fetch("https://api.morgen.so/v3/tasks/tracking/create", {
-            method: "POST",
-            headers: {
-            "accept": "application/json",
-            "Authorization": "ApiKey <API_KEY>"
-            },
-            body: JSON.stringify({
-              "taskId": "<TASK_ID>",
-              "start": "2023-03-15T09:00:00Z",
-              "duration": "PT2H30M",
-              "billable": true
-            })
-        });
-        ```
-    </Tabs.Tab>
-    <Tabs.Tab>
-        ```js
-        fetch("https://api.morgen.so/v3/tasks/tracking/create", {
-            method: "POST",
-            headers: {
-            "accept": "application/json",
-            "Authorization": "Bearer <JWT>"
-            },
-            body: JSON.stringify({
-              "taskId": "<TASK_ID>",
-              "start": "2023-03-15T09:00:00Z",
-              "duration": "PT2H30M",
-              "billable": true
-            })
-        });
-        ```
-    </Tabs.Tab>
-</Tabs>
-
-### Request Body Fields
-
-| Field | Type | Required | Description |
-| :---- | :--- | :------- | :---------- |
-| `taskId` | String | Yes | The Morgen ID of the task to track time for. |
-| `start` | String | Yes | Start time of the interval in ISO 8601 format. |
-| `duration` | String | Yes | Duration in ISO 8601 format (e.g., `"PT2H30M"` for 2 hours 30 minutes). |
-| `billable` | Boolean | No | Whether this time is billable. Default: `false`. |
 
 ### Response
 

--- a/pages/tasks.mdx
+++ b/pages/tasks.mdx
@@ -1,0 +1,617 @@
+import { Callout, Tabs } from "nextra/components";
+
+# Tasks
+
+Morgen allows you to manage tasks through a unified API.
+Tasks follow a data model inspired by the [JSCalendar standard](https://datatracker.ietf.org/doc/rfc8984/).
+
+## List tasks
+
+Returns a list of tasks, optionally filtered by update time.
+
+<Tabs items={['API Key', 'JWT Token']}>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/list?limit=<LIMIT>&updatedAfter=<UPDATED_AFTER>", {
+            method: "GET",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "ApiKey <API_KEY>"
+            }
+        });
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/list?limit=<LIMIT>&updatedAfter=<UPDATED_AFTER>", {
+            method: "GET",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "Bearer <JWT>"
+            }
+        });
+        ```
+    </Tabs.Tab>
+</Tabs>
+
+| Parameter      | Type  | Default | Required | Description                                                    |
+| :------------- | :---- | :------ | :------- | :------------------------------------------------------------- |
+| `limit`        | Query | -       | No       | Maximum number of tasks to return.                             |
+| `updatedAfter` | Query | -       | No       | Only return tasks updated after this ISO 8601 datetime.        |
+
+<Callout type="warning" emoji="⚠️">
+  The Tasks API is primarily designed for creating tasks in Morgen from unsupported integrations.
+  Listing tasks has a higher rate limit cost based on the `limit` parameter.
+  See [Rate Limits](/rate-limits) for details.
+</Callout>
+
+## Task schema
+
+Here is an example response for the `/tasks/list` endpoint:
+
+```json
+{
+  "data": {
+    "tasks": [
+      {
+        "@type": "Task",
+
+        // Morgen ID for task
+        "id": "WyJBUU1rQURaa1lXWXpOel...",
+
+        // Morgen ID for the account
+        "accountId": "640a62c9aa5b7e06cf420000",
+
+        "integrationId": "morgen",
+
+        // Task list this task belongs to
+        "taskListId": "default",
+
+        "created": "2023-02-28T11:50:57",
+        "updated": "2023-02-28T17:56:44",
+
+        "title": "Review quarterly report",
+        "description": "Review and provide feedback on Q4 report",
+        "descriptionContentType": "text/plain",
+
+        // Due date in LocalDateTime format
+        "due": "2023-03-15T17:00:00",
+        "timeZone": "Europe/Berlin",
+
+        // Estimated time to complete (ISO 8601 duration)
+        "estimatedDuration": "PT2H",
+
+        // Priority: 0 = undefined, 1 = highest, 9 = lowest
+        "priority": 1,
+
+        // Task completion status
+        "progress": "needs-action",
+
+        // Position within the task list (for ordering)
+        "position": 0,
+
+        // Relations to other tasks (for subtasks)
+        "relatedTo": {
+          "parent-task-id": {
+            "@type": "Relation",
+            "relation": { "parent": true }
+          }
+        },
+
+        // Morgen-specific derived fields (read-only)
+        "morgen.so:derived": {
+          "scheduled": true
+        }
+      }
+    ],
+    // Label definitions for task metadata
+    "labelDefs": [...],
+    // Spaces/workspaces the tasks belong to
+    "spaces": [...]
+  }
+}
+```
+
+### Task Fields Reference
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| `@type` | String | Always `"Task"` |
+| `id` | String | Morgen's unique identifier for the task |
+| `accountId` | String | ID of the account the task belongs to |
+| `integrationId` | String | Integration provider (`"morgen"`) |
+| `taskListId` | String | ID of the task list containing this task |
+| `title` | String | Task title/summary |
+| `description` | String | Task description (plain text or HTML) |
+| `descriptionContentType` | String | Either `"text/plain"` or `"text/html"` |
+| `due` | String | Due date in LocalDateTime format (e.g., `"2023-03-15T17:00:00"`) |
+| `timeZone` | String | IANA timezone for the due date |
+| `estimatedDuration` | String | Estimated duration in ISO 8601 format (e.g., `"PT2H"`) |
+| `priority` | Number | Priority level: 0 (undefined), 1 (highest) to 9 (lowest) |
+| `progress` | String | Status: `"needs-action"`, `"in-process"`, `"completed"`, `"failed"`, `"cancelled"` |
+| `position` | Number | Sort order within the task list |
+| `relatedTo` | Object | Relations to other tasks (for subtask hierarchies) |
+| `created` | String | Creation timestamp (UTC) |
+| `updated` | String | Last update timestamp (UTC) |
+
+<Callout type="warning" emoji="⚠️">
+  Additional fields might be added in the future. If you are storing tasks
+  in your database, please make sure to ignore unknown fields.
+</Callout>
+
+## Get a task
+
+Retrieve a single task by its ID.
+
+<Tabs items={['API Key', 'JWT Token']}>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks?id=<TASK_ID>", {
+            method: "GET",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "ApiKey <API_KEY>"
+            }
+        });
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks?id=<TASK_ID>", {
+            method: "GET",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "Bearer <JWT>"
+            }
+        });
+        ```
+    </Tabs.Tab>
+</Tabs>
+
+| Parameter | Type  | Default | Required | Description              |
+| :-------- | :---- | :------ | :------- | :----------------------- |
+| `id`      | Query | -       | Yes      | The Morgen ID of the task to retrieve. |
+
+### Response
+
+```json
+{
+  "data": {
+    "task": {
+      "@type": "Task",
+      "id": "WyJBUU1rQURaa1lXWXpOel...",
+      "title": "Review quarterly report",
+      ...
+    },
+    "labelDefs": [...]
+  }
+}
+```
+
+## Create a task
+
+Create a new task in Morgen.
+
+<Tabs items={['API Key', 'JWT Token']}>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/create", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "ApiKey <API_KEY>"
+            },
+            body: JSON.stringify({
+              "title": "Review quarterly report",
+              "description": "Review and provide feedback",
+              "due": "2023-03-15T17:00:00",
+              "timeZone": "Europe/Berlin",
+              "priority": 1
+            })
+        });
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/create", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "Bearer <JWT>"
+            },
+            body: JSON.stringify({
+              "title": "Review quarterly report",
+              "description": "Review and provide feedback",
+              "due": "2023-03-15T17:00:00",
+              "timeZone": "Europe/Berlin",
+              "priority": 1
+            })
+        });
+        ```
+    </Tabs.Tab>
+</Tabs>
+
+### Request Body Fields
+
+| Field | Type | Required | Description |
+| :---- | :--- | :------- | :---------- |
+| `title` | String | Yes | Task title (minimum 1 character). |
+| `description` | String | No | Task description. |
+| `descriptionContentType` | String | No | `"text/plain"` or `"text/html"`. Default: `"text/plain"`. |
+| `due` | String | No | Due date in LocalDateTime format (exactly 19 characters: `YYYY-MM-DDTHH:mm:ss`). |
+| `timeZone` | String | No | IANA timezone for the due date. |
+| `estimatedDuration` | String | No | Estimated duration in ISO 8601 format. |
+| `taskListId` | String | No | ID of the task list to add the task to. |
+| `priority` | Number | No | Priority: 0 (undefined), 1 (highest) to 9 (lowest). |
+| `progress` | String | No | Initial status: `"needs-action"` or `"completed"`. |
+| `relatedTo` | Object | No | Relations for creating subtasks. |
+
+### Response
+
+```json
+{
+  "data": {
+    "id": "WyJBUU1rQURaa1lXWXpOel..."
+  }
+}
+```
+
+### Creating Subtasks
+
+To create a subtask, use the `relatedTo` field to specify the parent task:
+
+```json
+{
+  "title": "Subtask title",
+  "relatedTo": {
+    "<PARENT_TASK_ID>": {
+      "@type": "Relation",
+      "relation": { "parent": true }
+    }
+  }
+}
+```
+
+## Update a task
+
+Update an existing task. Only include the fields you want to change.
+
+<Tabs items={['API Key', 'JWT Token']}>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/update", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "ApiKey <API_KEY>"
+            },
+            body: JSON.stringify({
+              "id": "<TASK_ID>",
+              "title": "Updated title"
+            })
+        });
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/update", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "Bearer <JWT>"
+            },
+            body: JSON.stringify({
+              "id": "<TASK_ID>",
+              "title": "Updated title"
+            })
+        });
+        ```
+    </Tabs.Tab>
+</Tabs>
+
+### Request Body Fields
+
+| Field | Type | Required | Description |
+| :---- | :--- | :------- | :---------- |
+| `id` | String | Yes | The Morgen ID of the task to update. |
+| `title` | String | No | Updated task title. |
+| `description` | String | No | Updated description. |
+| `due` | String | No | Updated due date. |
+| `timeZone` | String | No | Updated timezone. |
+| `taskListId` | String | No | Move task to a different task list. |
+| `priority` | Number | No | Updated priority (0-9). |
+| `progress` | String | No | Updated status. |
+| `labels` | Array | No | Task labels. |
+
+<Callout type="info" emoji="💡">
+  Updates are patch updates. Only the fields you provide will be updated.
+  All other fields remain unchanged.
+</Callout>
+
+### Response
+
+Returns HTTP 204 No Content on success.
+
+## Move a task
+
+Reorder a task within its list or change its parent (for subtask hierarchies).
+
+<Tabs items={['API Key', 'JWT Token']}>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/move", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "ApiKey <API_KEY>"
+            },
+            body: JSON.stringify({
+              "id": "<TASK_ID>",
+              "previousId": "<PREVIOUS_TASK_ID>",
+              "parentId": "<PARENT_TASK_ID>"
+            })
+        });
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/move", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "Bearer <JWT>"
+            },
+            body: JSON.stringify({
+              "id": "<TASK_ID>",
+              "previousId": "<PREVIOUS_TASK_ID>",
+              "parentId": "<PARENT_TASK_ID>"
+            })
+        });
+        ```
+    </Tabs.Tab>
+</Tabs>
+
+### Request Body Fields
+
+| Field | Type | Required | Description |
+| :---- | :--- | :------- | :---------- |
+| `id` | String | Yes | The Morgen ID of the task to move. |
+| `previousId` | String | No | ID of the task this should appear after. Use `null` to move to first position. |
+| `parentId` | String | No | ID of the parent task. Use `null` to move to root level. |
+
+### Response
+
+Returns HTTP 204 No Content on success.
+
+## Delete a task
+
+Delete a task permanently.
+
+<Tabs items={['API Key', 'JWT Token']}>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/delete", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "ApiKey <API_KEY>"
+            },
+            body: JSON.stringify({
+              "id": "<TASK_ID>"
+            })
+        });
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/delete", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "Bearer <JWT>"
+            },
+            body: JSON.stringify({
+              "id": "<TASK_ID>"
+            })
+        });
+        ```
+    </Tabs.Tab>
+</Tabs>
+
+### Request Body Fields
+
+| Field | Type | Required | Description |
+| :---- | :--- | :------- | :---------- |
+| `id` | String | Yes | The Morgen ID of the task to delete. |
+
+### Response
+
+Returns HTTP 204 No Content on success.
+
+## Close a task
+
+Mark a task as completed.
+
+<Tabs items={['API Key', 'JWT Token']}>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/close", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "ApiKey <API_KEY>"
+            },
+            body: JSON.stringify({
+              "id": "<TASK_ID>"
+            })
+        });
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/close", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "Bearer <JWT>"
+            },
+            body: JSON.stringify({
+              "id": "<TASK_ID>"
+            })
+        });
+        ```
+    </Tabs.Tab>
+</Tabs>
+
+### Request Body Fields
+
+| Field | Type | Required | Description |
+| :---- | :--- | :------- | :---------- |
+| `id` | String | Yes | The Morgen ID of the task to close. |
+| `occurrenceStart` | String | No | For recurring tasks: ISO 8601 datetime of the specific occurrence to close. |
+
+### Response
+
+Returns HTTP 204 No Content on success.
+
+## Reopen a task
+
+Mark a completed task as not completed.
+
+<Tabs items={['API Key', 'JWT Token']}>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/reopen", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "ApiKey <API_KEY>"
+            },
+            body: JSON.stringify({
+              "id": "<TASK_ID>"
+            })
+        });
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/reopen", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "Bearer <JWT>"
+            },
+            body: JSON.stringify({
+              "id": "<TASK_ID>"
+            })
+        });
+        ```
+    </Tabs.Tab>
+</Tabs>
+
+### Request Body Fields
+
+| Field | Type | Required | Description |
+| :---- | :--- | :------- | :---------- |
+| `id` | String | Yes | The Morgen ID of the task to reopen. |
+| `occurrenceStart` | String | No | For recurring tasks: ISO 8601 datetime of the specific occurrence to reopen. |
+
+### Response
+
+Returns HTTP 204 No Content on success.
+
+## Create a time tracking interval
+
+Record time spent working on a task.
+
+<Tabs items={['API Key', 'JWT Token']}>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/tracking/create", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "ApiKey <API_KEY>"
+            },
+            body: JSON.stringify({
+              "taskId": "<TASK_ID>",
+              "start": "2023-03-15T09:00:00Z",
+              "duration": "PT2H30M",
+              "billable": true
+            })
+        });
+        ```
+    </Tabs.Tab>
+    <Tabs.Tab>
+        ```js
+        fetch("https://api.morgen.so/v3/tasks/tracking/create", {
+            method: "POST",
+            headers: {
+            "accept": "application/json",
+            "Authorization": "Bearer <JWT>"
+            },
+            body: JSON.stringify({
+              "taskId": "<TASK_ID>",
+              "start": "2023-03-15T09:00:00Z",
+              "duration": "PT2H30M",
+              "billable": true
+            })
+        });
+        ```
+    </Tabs.Tab>
+</Tabs>
+
+### Request Body Fields
+
+| Field | Type | Required | Description |
+| :---- | :--- | :------- | :---------- |
+| `taskId` | String | Yes | The Morgen ID of the task to track time for. |
+| `start` | String | Yes | Start time of the interval in ISO 8601 format. |
+| `duration` | String | Yes | Duration in ISO 8601 format (e.g., `"PT2H30M"` for 2 hours 30 minutes). |
+| `billable` | Boolean | No | Whether this time is billable. Default: `false`. |
+
+### Response
+
+Returns HTTP 204 No Content on success.
+
+## Common Validation Errors
+
+### Invalid Due Date Format
+
+**Error Message**:
+```
+due must be a valid ISO 8601 date string
+```
+
+**Cause**: The due date is not in the correct format.
+
+**Solution**: Use exactly 19 characters in LocalDateTime format: `YYYY-MM-DDTHH:mm:ss`
+
+**Example**: `"2023-03-15T17:00:00"` (not `"2023-03-15"` or `"2023-03-15T17:00:00Z"`)
+
+---
+
+### Invalid Priority Value
+
+**Error Message**:
+```
+priority must not be greater than 9
+priority must not be less than 0
+```
+
+**Cause**: Priority value is outside the valid range.
+
+**Solution**: Use a value between 0 and 9, where 0 is undefined and 1 is highest priority.
+
+---
+
+### Missing Required Title
+
+**Error Message**:
+```
+title must be longer than or equal to 1 characters
+```
+
+**Cause**: Task title is empty or missing.
+
+**Solution**: Provide a title with at least 1 character when creating a task.


### PR DESCRIPTION
## TODO
- [ ] Proofread docs, I can't view due to the failing error unless i fix the syntax of all of them, which is what led me to the other PR https://github.com/morgen-so/morgen-dev-docs/pull/14

## Summary

This PR updates the developer documentation to document the v3 Tasks API and fixes a broken development environment caused by version inconsistencies.

## Migration Context

The development build was failing due to a mismatch between dependency versions and syntax:
- `package.json` had `nextra: "latest"` and `nextra-theme-docs: "latest"` which resolved to v4.x
- However, the codebase was using Nextra v2.x syntax (CommonJS `require()`, `pages/` directory structure, `theme.config.tsx`), not sure if I was missing anything related to running locally that i'm unaware of, i tried doing `npm install` and it didn't seem to resolve @marcoancona 
- This caused the dev server to fail with incompatible configuration errors

The fix required a full migration to Nextra v4, details outlined in the other PR

## Changes
- Added Tasks API v3 documentation (`content/tasks.mdx`):
  - List, Get, Create, Update, Move, Delete endpoints
  - Close/Reopen task endpoints
  - Time tracking endpoint
  - Task schema and field reference
  - Common validation errors
  - Rate limit warning callout linking to rate limits page
- Added Rate Limits documentation (`content/rate-limits.mdx`):
  - Points system for API Key authentication (250 points / 15 min)
  - JWT token limits (300 requests / 15 min)
  - Rate limit response headers (`RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`, `Retry-After`)
  - Best practices for handling rate limits
