### PR TITLE
Clarify timeZone: null and floating event support in events docs

### DIFF
--- a/content/events.mdx
+++ b/content/events.mdx
@@ -289,7 +289,7 @@ fetch("https://api.morgen.so/v3/events/create", {
 | `title`                  | String         | Yes      | The title/summary of the event.                                                                                |
 | `start`                  | String         | Yes      | Start time in LocalDateTime format (e.g., `2023-03-01T10:15:00`).                                              |
 | `duration`               | String         | Yes      | Duration in ISO 8601 format (e.g., `PT1H` for 1 hour, `PT30M` for 30 minutes).                                 |
-| `timeZone`               | String or null | Yes      | IANA timezone (e.g., `Europe/Paris`). Use `null` for floating events (no timezone).                            |
+| `timeZone`               | String or null | Yes      | IANA timezone for timed events (e.g., `Europe/Paris`). Use `null` for all-day events (`showWithoutTime: true`). See the note below on floating timed events. |
 | `showWithoutTime`        | Boolean        | Yes      | `true` for all-day events, `false` for timed events.                                                           |
 | `description`            | String         | No       | Event description. Can be plain text or HTML (specify with `descriptionContentType`).                          |
 | `descriptionContentType` | String         | No       | Either `text/plain` or `text/html`. Default: `text/plain`.                                                     |
@@ -302,6 +302,18 @@ fetch("https://api.morgen.so/v3/events/create", {
 | `recurrenceRules`        | Array          | No       | Array of recurrence rule objects for recurring events.                                                         |
 
 Other fields from the [JSCalendar standard](https://datatracker.ietf.org/doc/rfc8984/) are also supported.
+
+<Callout type="warning" emoji="⚠️">
+  **Floating (no-timezone) timed events are not reliably preserved.** The API
+  accepts `timeZone: null` on a timed event (`showWithoutTime: false`), but a
+  floating time is not currently carried through end to end when the event is
+  written to a connected calendar, and the behavior varies by provider:
+  iCloud/CalDAV rejects a timed event that has no timezone, and Microsoft 365
+  fills in a concrete zone (often `Africa/Abidjan`, UTC+0) rather than keeping
+  the time floating. For timed events, always provide an explicit IANA timezone.
+  `null` is intended for all-day events (`showWithoutTime: true`), where no
+  timezone applies.
+</Callout>
 
 ## Update an event
 

--- a/content/events.mdx
+++ b/content/events.mdx
@@ -569,6 +569,8 @@ Properties `start`, `duration`, `timeZone` and `showWithoutTime` must be provide
 
 **Solution**: Always provide all four fields together: `start`, `duration`, `timeZone`, and `showWithoutTime`.
 
+**Note**: Although the error message mentions that `timeZone` can be `null`, reserve `null` for all-day events (`showWithoutTime: true`). Do not use it for floating (no-timezone) timed events: as described in the warning under [Create an event](#create-an-event), those are not reliably preserved across calendar backends (providers may reject them or normalize them to a concrete zone). For timed events, always provide an explicit IANA timezone.
+
 **Example**:
 
 ```json


### PR DESCRIPTION
## TL;DR

- The events API docs stated a timed event's `timeZone` may be `null` to represent a floating (no-timezone) event, but the sync layer does not preserve floating timed events end to end. This corrects that claim so the docs no longer promise more than the write path delivers.
- Reworded the `timeZone` field description in the create-event request body table and added a warning callout describing the real per-provider behavior.

## Design Decisions

- Scoped `null` to its accurate use in the field table (all-day events, `showWithoutTime: true`) and pointed readers to the new callout for the timed-event caveat.
- Added a `Callout type="warning"` block (matching the variant already used elsewhere in `content/events.mdx`) rather than touching the "Common Validation Errors" section, since that section quotes the API's actual error string verbatim and stays accurate.
- Documented the concrete observed behavior so integrators know what to expect instead of relying on undocumented coercion: iCloud/CalDAV rejects a timed event with no timezone, and Microsoft 365 fills in a concrete zone (often `Africa/Abidjan`, UTC+0).
- Documentation-accuracy fix only: no change to the API contract or the quoted error message.

## Testing

- Documentation-only change; no automated tests. Confirmed the `Callout` component and its `warning` variant are already in use in `content/events.mdx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified `timeZone` usage for timed events: it must include explicit IANA timezone data.
  - Specified that `timeZone: null` is intended only for all-day events (`showWithoutTime: true`).
  - Added a warning that floating (no-timezone) timed events may not be preserved consistently across connected providers, including possible rejection or normalization.
  - Updated validation guidance reinforcing the above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->