### PR TITLE
docs(MOR-4652): document /v3/events response contracts, error contract, and correct rate limits

### DIFF
--- a/content/authentication.mdx
+++ b/content/authentication.mdx
@@ -1,6 +1,48 @@
-import { Steps } from "nextra/components";
+import { Callout, Steps } from "nextra/components";
 
 # Morgen API Authentication
+
+## Base URL
+
+All Morgen API endpoints are served from:
+
+```
+https://api.morgen.so
+```
+
+Endpoints are versioned with a path prefix. The current version is `v3`, so a
+full endpoint URL looks like `https://api.morgen.so/v3/events/list`.
+
+## Authenticating a request
+
+Send your API key on the `Authorization` header, prefixed with `ApiKey` and a
+single space:
+
+```
+Authorization: ApiKey <YOUR_API_KEY>
+```
+
+For example:
+
+```js
+fetch("https://api.morgen.so/v3/tasks/list", {
+  method: "GET",
+  headers: {
+    accept: "application/json",
+    Authorization: "ApiKey <YOUR_API_KEY>",
+  },
+});
+```
+
+The scheme is `ApiKey`, not `Bearer`. A request with a missing or unrecognised
+`Authorization` header returns HTTP 401, and so does a request carrying a key
+that is not valid.
+
+<Callout type="warning" emoji="⚠️">
+  Access to the API also depends on your Morgen plan. If your key is valid but
+  your plan does not include API access, requests return HTTP 403 with the
+  message "Missing entitlements".
+</Callout>
 
 ## Get your API key
 

--- a/content/events.mdx
+++ b/content/events.mdx
@@ -768,6 +768,74 @@ Returns HTTP **204 No Content** on success, with an **empty response body**.
   which occurrences were affected.
 </Callout>
 
+## Errors
+
+Errors are produced by a single shared handler, so the status codes and body
+shapes below apply uniformly to every endpoint on this page, and to the rest of
+the Morgen API.
+
+| Status | When you will see it                                                                                                                                        |
+| :----- | :---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `400`  | The request failed validation: a missing or malformed field, an unknown property in the body or query string, or an ID that could not be resolved.           |
+| `401`  | The `Authorization` header is missing, malformed, or carries a key that is not valid. See [Authentication](/authentication).                                 |
+| `403`  | The key is valid but your plan does not include API access.                                                                                                  |
+| `429`  | You have exceeded your rate limit. See [Rate Limits](/rate-limits).                                                                                          |
+| `500`  | An unexpected server-side failure.                                                                                                                          |
+
+### Error body
+
+Errors that Morgen raises deliberately, which is everything in the table above
+except `500`, return this shape:
+
+```json
+{
+  "message": "Cannot apply 'all' series update mode to non-recurring events",
+  "status": 400,
+  "errorRef": "V1StGXR8Z5jd"
+}
+```
+
+| Field      | Always present | Description                                                                                                              |
+| :--------- | :------------- | :------------------------------------------------------------------------------------------------------------------------ |
+| `message`  | Yes            | A human-readable description of the failure. Intended for logs and debugging, not for matching on programmatically.       |
+| `status`   | No             | The HTTP status code, repeated in the body. See the warning below.                                                        |
+| `errorRef` | Yes            | An identifier for this specific failure.                                                                                  |
+| `context`  | No             | Present on some errors, with extra structured detail about what failed.                                                   |
+
+Fields with no value are removed from the body entirely rather than sent as
+`null`, so do not expect a fixed set of keys.
+
+For request-validation failures, `message` is a JSON-encoded list describing each
+field that failed, so it can be long and is not a stable, human-friendly string.
+
+Unexpected errors return a shorter body, with the underlying message replaced by
+a generic one so that internal detail is not exposed:
+
+```json
+{
+  "message": "Something went wrong. Please retry or contact us at connect@morgen.so.",
+  "errorRef": "V1StGXR8Z5jd"
+}
+```
+
+<Callout type="warning" emoji="⚠️">
+  **Do not rely on `status` being present in the error body.** It appears only on
+  errors Morgen raises deliberately. On an unexpected failure the field is absent
+  entirely, so a client written as `if (body.status >= 400)` reads `undefined`,
+  the comparison is false, and the request is treated as having succeeded,
+  precisely at the moment something has actually gone wrong. **Branch on the HTTP
+  status line, and treat the body as diagnostic detail only.** Note that this is
+  not purely a `500` concern: a request whose body is not valid JSON, or which
+  exceeds the maximum payload size, is rejected before it reaches the endpoint
+  and also returns the shorter shape, despite carrying a `4xx` status line.
+</Callout>
+
+<Callout type="info" emoji="💡">
+  Every error carries an `errorRef`, in both shapes. Quote it when you contact
+  support: it identifies the exact failure in our logs, and it is the fastest way
+  for us to diagnose a problem you cannot reproduce.
+</Callout>
+
 ## Common Validation Errors
 
 When creating or updating events, you may encounter validation errors. Here are the most common errors and how to resolve them:

--- a/content/events.mdx
+++ b/content/events.mdx
@@ -159,8 +159,10 @@ Here is an example response for the `/events/list` endpoint described above:
 }
 ```
 
-Fields that are empty or not applicable are omitted from the response rather than
-returned as `null`, so most of the fields above are absent on any given event.
+Fields with no value are omitted from the response rather than returned as
+`null`, so most of the fields above are absent on any given event. An empty
+object, such as `"alerts": {}`, is a value rather than an absent field and is
+returned as-is.
 
 ### Event Fields Reference
 
@@ -197,6 +199,7 @@ returned as `null`, so most of the fields above are absent on any given event.
 | `google.com:hangoutLink` | String  | Google Calendar only. Read-only Google Meet link.                                                                                                           |
 | `morgen.so:derived`      | Object  | Read-only fields derived from the rest of the event, for example a virtual room URL found in the description.                                                |
 | `morgen.so:metadata`     | Object  | Read-only Morgen-specific metadata: `categoryId`, `categoryName`, `categoryColor` (hex), and the task fields `progress` (`"needs-action"` or `"completed"`) and `taskId`. An event with a `taskId` is displayed as a task in Morgen. |
+| `morgen.so:requestVirtualRoom` | String | Write-only. Requests creation of a virtual meeting room: `"default"`, `"googleMeet"` or `"microsoftTeams"`. See [Request the creation of a virtual meeting room](#request-the-creation-of-a-virtual-meeting-room). |
 
 ### Event IDs
 
@@ -237,18 +240,12 @@ for more information about the data model. Please consider the following differe
 
 #### Additional fields
 
-Morgen returns some additional fields for convenience and to provide more information about the event:
+Morgen returns some additional fields for convenience and to provide more
+information about the event: `integrationId`, `accountId`, `calendarId`,
+`baseEventId`, `masterEventId`, `masterBaseEventId`, `morgen.so:derived`,
+`morgen.so:metadata`, `morgen.so:requestVirtualRoom` and `useDefaultAlerts`.
 
-- `integrationId`: The ID of the integration the event belongs to.
-- `accountId`: The ID of the account the event belongs to.
-- `calendarId`: The ID of the calendar the event belongs to.
-- `baseEventId`: The provider ID of the base event the event belongs to. This is the ID of the recurring event for recurring events, and the ID of the event itself for non-recurring events.
-- `masterEventId`: The Morgen ID of the master recurring event (for recurring event instances only). Can be used with `recurrenceId` to identify and update specific instances.
-- `masterBaseEventId`: The provider ID of the master base event the event belongs to. This is the ID of the master recurring event for recurring events, and will not be returned for non-recurring events.
-- `morgen.so:derived`: An object containing useful fields derived from other event information. Read-only.
-- `morgen.so:metadata`: An object containing Morgen-specific metadata, such as the event category and the link to a task.
-- `morgen.so:requestVirtualRoom`: Writable field to request creation of a virtual meeting room (`"default"` | `"googleMeet"` | `"microsoftTeams"`).
-- `useDefaultAlerts`: Boolean flag to use the calendar's default alert settings instead of custom alerts.
+Each is described in the [Event Fields Reference](#event-fields-reference).
 
 <Callout type="warning" emoji="⚠️">
   Additional fields might be added in the future. If you are storing the event
@@ -412,7 +409,7 @@ full, wrapped under `data.event`:
       "calendarId": "WyI2NDBhNjJjOW...",
       "accountId": "640a62c9aa5b7e06cf420000",
       "integrationId": "google",
-      "baseEventId": "AAkALgAAAAAAHYQDEapmEc2by...",
+      "baseEventId": "kki3mce...",
       "created": "2023-03-01T09:04:22.000Z",
       "updated": "2023-03-01T09:04:22.311Z",
       "title": "Team Meeting",
@@ -430,9 +427,10 @@ full, wrapped under `data.event`:
 ```
 
 The returned event has the same shape as the entries from `/events/list`, see
-[Event schema](#event-schema). Fields that are empty or not applicable are
-omitted rather than returned as `null`, so the exact set of keys varies by
-provider and by what you sent.
+[Event schema](#event-schema). Fields with no value are omitted rather than
+returned as `null`, so the exact set of keys varies by provider and by what you
+sent. An empty object, such as the `"alerts": {}` above, is a value rather than
+an absent field and is returned as-is.
 
 Read `data.event.id` to get the ID of the new event. See [Event
 IDs](#event-ids), in particular the note about recurring events, before storing

--- a/content/events.mdx
+++ b/content/events.mdx
@@ -784,8 +784,8 @@ the Morgen API.
 
 ### Error body
 
-Errors that Morgen raises deliberately, which is everything in the table above
-except `500`, return this shape:
+Errors that Morgen raises deliberately return this shape. In practice that is
+every case in the table above other than an unexpected `500`:
 
 ```json
 {

--- a/content/events.mdx
+++ b/content/events.mdx
@@ -243,9 +243,13 @@ for more information about the data model. Please consider the following differe
 Morgen returns some additional fields for convenience and to provide more
 information about the event: `integrationId`, `accountId`, `calendarId`,
 `baseEventId`, `masterEventId`, `masterBaseEventId`, `morgen.so:derived`,
-`morgen.so:metadata`, `morgen.so:requestVirtualRoom` and `useDefaultAlerts`.
+`morgen.so:metadata` and `useDefaultAlerts`.
 
-Each is described in the [Event Fields Reference](#event-fields-reference).
+There is also one write-only field, `morgen.so:requestVirtualRoom`, which you can
+send on create and update but will never receive back.
+
+All of them are described in the [Event Fields
+Reference](#event-fields-reference).
 
 <Callout type="warning" emoji="⚠️">
   Additional fields might be added in the future. If you are storing the event

--- a/content/events.mdx
+++ b/content/events.mdx
@@ -207,9 +207,10 @@ The `id` field is Morgen's identifier for an event, and is what `/events/update`
   implementation detail and may change without notice.
 - **Pass it back byte for byte**, exactly as you received it. Do not URL-decode,
   re-encode, trim, or case-fold it.
-- **An `id` is only meaningful within the account it came from.** IDs are not
-  portable between accounts, and an ID from one account will be rejected with an
-  invalid ID error if used against another.
+- **An `id` is only meaningful within the account it came from.** Always pair an
+  `id` with the same `accountId` it was returned with. IDs are not portable
+  between accounts, and using one against a different account fails or resolves
+  to the wrong event rather than being silently ignored.
 - **`id` and `calendarId` are not interchangeable.** They are different kinds of
   identifier, and passing one where the other is expected fails.
 - **`uid` is not the `id`.** `uid` is the provider's iCalendar UID and is not

--- a/content/events.mdx
+++ b/content/events.mdx
@@ -33,6 +33,32 @@ fetch(
 | `start`       | Query | -       | Yes      | Start of the time window in ISO 8601 format, e.g. `2023-03-01T00:00:00Z`                                                                                                                                                                |
 | `end`         | Query | -       | Yes      | End of the time window in ISO 8601 format, e.g. `2023-04-01T00:00:00Z`. This must be greater than `start`. The interval cannot be longer than 6 months. It is recommended to retrieve no more than 2 months of events at the same time. |
 
+<Callout type="warning" emoji="⚠️">
+  Unknown query parameters are rejected. Sending a parameter that is not in the
+  table above returns HTTP 400, it is not ignored.
+</Callout>
+
+### Response
+
+Returns HTTP 200 OK. The events are returned as an array under `data.events`:
+
+```json
+{
+  "data": {
+    "events": []
+  }
+}
+```
+
+See [Event schema](#event-schema) below for the shape of each event.
+
+<Callout type="warning" emoji="⚠️">
+  Listing events costs 10 points per request. If you only need to read back a
+  single event you already have the ID for, use [Get an
+  event](#get-an-event) instead, which costs 1 point. See [Rate
+  Limits](/rate-limits) for details.
+</Callout>
+
 ## Event schema
 
 Here is an example response for the `/events/list` endpoint described above:
@@ -43,85 +69,40 @@ Here is an example response for the `/events/list` endpoint described above:
     "events": [
       {
         "@type": "Event",
-
-        // Morgen ID for event
         "id": "WyJBUU1rQURaa1lXWXpOel...",
-
-        // 3rd-party iCalendar UID
         "uid": "kki3mce...@google.com",
-
-        // Morgen ID for the calendar
         "calendarId": "WyI2NDBhNjJjOW...",
-
-        // Morgen ID for the account
         "accountId": "640a62c9aa5b7e06cf420000",
-
         "integrationId": "o365",
-
-        // 3rd-party ID for the base event in the recurrence
         "baseEventId": "AAkALgAAAAAAHYQDEapmEc2by...",
-
-        // For recurring event instances: Morgen ID of the master recurring event
         "masterEventId": "WyI2NDBhNjJjOWFhNWI3ZTA2Y2Y0MjAwMDA...",
-        // For recurring event instances: 3rd-party ID of the master recurring event
         "masterBaseEventId": "AAkALgAAAAAAHYQDEapmEc2by...",
-
         "created": "2023-02-28T11:50:57",
         "updated": "2023-02-28T17:56:44",
-
-        // ID + timezone that identify this event within the recurrence
         "recurrenceId": "2023-08-29T16:00:00",
         "recurrenceIdTimeZone": "Europe/Zurich",
-
         "title": "Chat about Morgen",
         "description": "<html><body>Description of event, possibly in HTML format.</body></html>",
-        // Either "text/plain" or "text/html" depending on content
         "descriptionContentType": "text/html",
-
-        // Start time of the event. Notice that this does not include a time zone offset.
-        // Instead, the time zone is specified in the "timeZone" field.
         "start": "2023-03-01T10:15:00",
         "timeZone": "Europe/Berlin",
-
-        // Duration in ISO format: 'PT[hours]H' | 'PT[minutes]M'
         "duration": "PT25M",
-
-        // If true, this event is an all-day event. Otherwise it occurs at a specific time in the day.
         "showWithoutTime": false,
-
-        // Whether the event details can be displayed to others users with access to the calendar.
         "privacy": "public",
-
-        // Whether the event is marked "busy" for the participants. Otherwise "free".
         "freeBusyStatus": "free",
-
         "locations": {
           "1": {
             "@type": "Location",
             "name": "Morgen HQ, Forrlibuckstrasse 223"
           }
         },
-
         "participants": {
-          // Map of participant IDs to participants.
-          // The key can be the participant's email address or an internal ID.
           "doe@morgen.so": {
             "@type": "Participant",
             "name": "John Doe",
-
-            // Email address of the participant
-            // NOTE: Sometimes, the participant email is a group email,
-            //       e.g. if the event was created in a secondary Google
-            //       calendar.
             "email": "doe@morgen.so",
-
             "roles": {
-              // Whether this participant will be attending
               "attendee": true,
-
-              // Whether the participant owns the event and can
-              // therefore make changes that affect other
-              // participants
               "owner": true
             },
             "participationStatus": "needs-action"
@@ -133,37 +114,22 @@ Here is an example response for the `/events/list` endpoint described above:
             "roles": {
               "attendee": true
             },
-
-            // Indicates whether this participant is also the owner of
-            // the calendar account
             "accountOwner": true,
             "participationStatus": "needs-action"
-          },
-          ...
+          }
         },
-
-
         "alerts": {
-          // Map of alert IDs to alerts.
-          // Alert IDs are base64-encoded: btoa(JSON.stringify({ a: action, to: offset }))
           "eyJhIjoiZGlzcGxheSIsInRvIjoiLVBUMTVNIn0=": {
             "@type": "Alert",
             "trigger": {
               "@type": "OffsetTrigger",
-              // Offset in ISO format: 'PT[hours]H' | 'PT[minutes]M'
-              // In this case, 15 minutes before the event start time.
               "offset": "-PT15M",
-              "relativeTo": "start" // only "start" is supported at the current time
+              "relativeTo": "start"
             },
             "action": "display"
-          },
-          ...
+          }
         },
-
-        // Use default calendar alerts instead of custom alerts
         "useDefaultAlerts": false,
-
-        // Recurrence rules for recurring events
         "recurrenceRules": [
           {
             "@type": "RecurrenceRule",
@@ -172,41 +138,101 @@ Here is an example response for the `/events/list` endpoint described above:
             "byDay": [{ "@type": "NDay", "day": "mo" }]
           }
         ],
-
-        // Google Calendar specific fields
-        "google.com:colorId": "5", // Writable: Google's event color ID (1-11)
+        "google.com:colorId": "5",
         "google.com:hangoutLink": "https://meet.google.com/abc-defg-hij",
-      },
-
-      // Derived, read-only fields.
-      // For example a virtual room URL if found in the event description.
-      "morgen.so:derived": {
-        "virtualRoom": {
-          "url": "https://us02web.zoom.us/j/82...?pwd=..."
+        "morgen.so:derived": {
+          "virtualRoom": {
+            "url": "https://us02web.zoom.us/j/82...?pwd=..."
+          }
+        },
+        "morgen.so:metadata": {
+          "updated": "2023-09-25T08:53:36.793Z",
+          "categoryId": "9b5f823f-d690-4781-8783-95052ac05740@morgen.so",
+          "categoryName": "Morgen",
+          "categoryColor": "#CCEACD",
+          "progress": "needs-action",
+          "taskId": "0d464578-08ff-4df6-88b2-19083b296df7"
         }
-      },
-
-      // Metadata, read-only, Morgen-specific fields.
-      "morgen.so:metadata": {
-        "updated": "2023-09-25T08:53:36.793Z"
-        // Category-related fields
-        "categoryId": "9b5f823f-d690-4781-8783-95052ac05740@morgen.so",
-        "categoryName": "Morgen",
-        "categoryColor": "#CCEACD", // Hexadecimal color code
-        // Task-related fields. An event with a taskId will be displayed as a task in the Morgen calendar.
-        "progress": "needs-action", // Possible values: "needs-action", "completed".
-        "taskId": "0d464578-08ff-4df6-88b2-19083b296df7",
       }
     ]
   }
 }
-
 ```
+
+Fields that are empty or not applicable are omitted from the response rather than
+returned as `null`, so most of the fields above are absent on any given event.
+
+### Event Fields Reference
+
+| Field                    | Type    | Description                                                                                                                                                 |
+| :----------------------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@type`                  | String  | Always `"Event"`                                                                                                                                            |
+| `id`                     | String  | Morgen's identifier for the event. See [Event IDs](#event-ids).                                                                                             |
+| `uid`                    | String  | The provider's iCalendar UID. This is **not** the `id`, and no endpoint accepts it in place of `id`.                                                         |
+| `calendarId`             | String  | Morgen ID of the calendar the event belongs to.                                                                                                             |
+| `accountId`              | String  | Morgen ID of the account the event belongs to.                                                                                                              |
+| `integrationId`          | String  | The provider the event came from, e.g. `"google"`, `"o365"`, `"caldav"`.                                                                                     |
+| `baseEventId`            | String  | The provider's ID for the base event. For recurring events this is the ID of the series, for non-recurring events it is the ID of the event itself.          |
+| `masterEventId`          | String  | Recurring instances only: the Morgen ID of the master recurring event. Can be used with `recurrenceId` to identify and update a specific instance.           |
+| `masterBaseEventId`      | String  | Recurring instances only: the provider's ID of the master recurring event. Not returned for non-recurring events.                                            |
+| `created`                | String  | Creation timestamp.                                                                                                                                         |
+| `updated`                | String  | Last update timestamp.                                                                                                                                      |
+| `recurrenceId`           | String  | Recurring instances only: the LocalDateTime that identifies this occurrence within the series, e.g. `"2023-08-29T16:00:00"`.                                 |
+| `recurrenceIdTimeZone`   | String  | IANA timezone for `recurrenceId`.                                                                                                                           |
+| `title`                  | String  | Event title/summary.                                                                                                                                        |
+| `description`            | String  | Event description, plain text or HTML.                                                                                                                      |
+| `descriptionContentType` | String  | Either `"text/plain"` or `"text/html"`, depending on the content of `description`.                                                                           |
+| `start`                  | String  | Start time in LocalDateTime format. Note that this carries **no** timezone offset, the zone is given separately in `timeZone`.                               |
+| `timeZone`               | String  | IANA timezone the `start` is expressed in.                                                                                                                  |
+| `duration`               | String  | Duration in ISO 8601 format, e.g. `"PT25M"`.                                                                                                                 |
+| `showWithoutTime`        | Boolean | `true` for an all-day event, `false` for an event at a specific time of day.                                                                                 |
+| `privacy`                | String  | `"public"`, `"private"` or `"secret"`. Whether the event details can be shown to other users with access to the calendar.                                    |
+| `freeBusyStatus`         | String  | `"free"` or `"busy"`. Whether the event marks the participants as busy.                                                                                      |
+| `locations`              | Object  | Map of location IDs to location objects.                                                                                                                    |
+| `participants`           | Object  | Map of participant IDs to participant objects. The key can be the participant's email address or an internal ID. Note that the email is sometimes a group address, for example when the event lives in a secondary Google calendar. |
+| `alerts`                 | Object  | Map of alert IDs to alert objects. The alert ID is derived from the alert's action and offset, see [Updating Alerts](#updating-alerts). Only `relativeTo: "start"` is currently supported. |
+| `useDefaultAlerts`       | Boolean | If `true`, the calendar's default alerts apply instead of the alerts in `alerts`.                                                                            |
+| `recurrenceRules`        | Array   | Recurrence rules, for recurring events.                                                                                                                     |
+| `google.com:colorId`     | String  | Google Calendar only. Read/write, see [Google Calendar Color ID](#google-calendar-color-id).                                                                 |
+| `google.com:hangoutLink` | String  | Google Calendar only. Read-only Google Meet link.                                                                                                           |
+| `morgen.so:derived`      | Object  | Read-only fields derived from the rest of the event, for example a virtual room URL found in the description.                                                |
+| `morgen.so:metadata`     | Object  | Read-only Morgen-specific metadata: `categoryId`, `categoryName`, `categoryColor` (hex), and the task fields `progress` (`"needs-action"` or `"completed"`) and `taskId`. An event with a `taskId` is displayed as a task in Morgen. |
+
+### Event IDs
+
+The `id` field is Morgen's identifier for an event, and is what `/events/update`,
+`/events/delete` and `GET /v3/events` expect. Treat it as an **opaque string**:
+
+- **Do not parse it, construct it, or transform it.** Its internal format is an
+  implementation detail and may change without notice.
+- **Pass it back byte for byte**, exactly as you received it. Do not URL-decode,
+  re-encode, trim, or case-fold it.
+- **An `id` is only meaningful within the account it came from.** IDs are not
+  portable between accounts, and an ID from one account will be rejected with an
+  invalid ID error if used against another.
+- **`id` and `calendarId` are not interchangeable.** They are different kinds of
+  identifier, and passing one where the other is expected fails.
+- **`uid` is not the `id`.** `uid` is the provider's iCalendar UID and is not
+  accepted by any endpoint that asks for an `id`.
+
+<Callout type="warning" emoji="⚠️">
+  **For recurring events, the `id` returned by `/events/create` is not the `id`
+  returned by `/events/list`.** Creating a recurring event returns the ID of the
+  master series. Listing events expands the series, so each occurrence comes back
+  with its own distinct instance ID. To match a listed occurrence back to the
+  series you created, compare its `masterEventId` field against the ID that
+  `create` returned, not its `id`.
+</Callout>
+
+<Callout type="info" emoji="💡">
+  For **non-recurring** events, the ID returned by `create` is the same string
+  that `list` returns and that `update`, `delete` and `GET /v3/events` accept.
+</Callout>
+
+### Differences with JSCalendar
 
 Please refer to the [JSCalendar standard](https://datatracker.ietf.org/doc/rfc8984/)
 for more information about the data model. Please consider the following differences:
-
-### Differences with JSCalendar
 
 #### Additional fields
 
@@ -264,6 +290,61 @@ For Google Calendar events, you can set the event color using the `google.com:co
   etc.) will have no effect.
 </Callout>
 
+## Get an event
+
+Retrieve a single event by its ID. Unlike `/events/list`, this does not require a
+time window and does not expand recurring series, it returns exactly the event
+whose ID you pass.
+
+```js
+fetch("https://api.morgen.so/v3/events?id=<EVENT_ID>", {
+  method: "GET",
+  headers: {
+    accept: "application/json",
+    Authorization: "ApiKey <API_KEY>",
+  },
+});
+```
+
+| Parameter | Type  | Default | Required | Description                             |
+| :-------- | :---- | :------ | :------- | :-------------------------------------- |
+| `id`      | Query | -       | Yes      | The Morgen ID of the event to retrieve. |
+
+### Response
+
+Returns HTTP 200 OK with the event wrapped under `data.event`:
+
+```json
+{
+  "data": {
+    "event": {
+      "@type": "Event",
+      "id": "WyJBUU1rQURaa1lXWXpOel...",
+      "calendarId": "WyI2NDBhNjJjOW...",
+      "accountId": "640a62c9aa5b7e06cf420000",
+      "integrationId": "o365",
+      "title": "Chat about Morgen",
+      "start": "2023-03-01T10:15:00",
+      "timeZone": "Europe/Berlin",
+      "duration": "PT25M",
+      "showWithoutTime": false,
+      "privacy": "public",
+      "freeBusyStatus": "free"
+    }
+  }
+}
+```
+
+The event has the same shape as the entries returned by `/events/list`, see
+[Event schema](#event-schema).
+
+<Callout type="info" emoji="💡">
+  This endpoint costs 1 point per request, against 10 points for
+  `/events/list`. If you already have an event's ID, for example to read back an
+  event you just created or updated, prefer this endpoint. See [Rate
+  Limits](/rate-limits) for details.
+</Callout>
+
 ## Create an event
 
 Morgen offers an endpoint to create events in a given calendar.
@@ -315,6 +396,56 @@ Other fields from the [JSCalendar standard](https://datatracker.ietf.org/doc/rfc
   timezone applies.
 </Callout>
 
+### Response
+
+Returns HTTP **200 OK** on success, not 201. The created event is returned in
+full, wrapped under `data.event`:
+
+```json
+{
+  "data": {
+    "event": {
+      "@type": "Event",
+      "id": "WyJBUU1rQURaa1lXWXpOel...",
+      "uid": "kki3mce...@google.com",
+      "calendarId": "WyI2NDBhNjJjOW...",
+      "accountId": "640a62c9aa5b7e06cf420000",
+      "integrationId": "google",
+      "baseEventId": "AAkALgAAAAAAHYQDEapmEc2by...",
+      "created": "2023-03-01T09:04:22.000Z",
+      "updated": "2023-03-01T09:04:22.311Z",
+      "title": "Team Meeting",
+      "start": "2023-03-15T14:00:00",
+      "timeZone": "America/New_York",
+      "duration": "PT1H",
+      "showWithoutTime": false,
+      "privacy": "public",
+      "freeBusyStatus": "busy",
+      "alerts": {},
+      "useDefaultAlerts": true
+    }
+  }
+}
+```
+
+The returned event has the same shape as the entries from `/events/list`, see
+[Event schema](#event-schema). Fields that are empty or not applicable are
+omitted rather than returned as `null`, so the exact set of keys varies by
+provider and by what you sent.
+
+Read `data.event.id` to get the ID of the new event. See [Event
+IDs](#event-ids), in particular the note about recurring events, before storing
+it or passing it to another endpoint.
+
+<Callout type="warning" emoji="⚠️">
+  The create response cannot be sent back to `/events/create` or
+  `/events/update` as-is. Those endpoints reject unknown fields with HTTP 400,
+  and the response contains read-only fields (`id`, `uid`, `baseEventId`,
+  `created`, `updated`, `integrationId`, `morgen.so:derived`, and others) that
+  they do not accept. Send only the fields documented for the endpoint you are
+  calling.
+</Callout>
+
 ## Update an event
 
 The following endpoint can be used to update an event in a given calendar.
@@ -332,7 +463,20 @@ fetch("https://api.morgen.so/v3/events/update?seriesUpdateMode=<UPDATE_MODE>", {
 
 | Parameter          | Type  | Default  | Required | Description                                                                                                                                                                                                                              |
 | :----------------- | :---- | :------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `seriesUpdateMode` | Query | `single` | No       | Defines how to update recurring events. Possible values are: `all` (update all events), `future` (update this and future occurrences), `single` (update this event only, default). This parameter has no effect on non-recurring events. |
+| `seriesUpdateMode` | Query | `single` | No       | Defines how to update recurring events. Possible values are: `all` (update all events), `future` (update this and future occurrences), `single` (update this event only, default). |
+
+<Callout type="warning" emoji="⚠️">
+  **`seriesUpdateMode` is a query-string parameter only.** Putting it in the JSON
+  request body returns HTTP 400. The request body only accepts the event fields
+  documented below, and any property outside that set is rejected rather than
+  ignored.
+</Callout>
+
+<Callout type="info" emoji="💡">
+  On a **non-recurring** event, only omitting `seriesUpdateMode` or sending
+  `single` is accepted. Sending `all` or `future` returns HTTP 400 with a message
+  such as "Cannot apply 'all' series update mode to non-recurring events".
+</Callout>
 
 ### Request Body Fields
 
@@ -388,6 +532,44 @@ fetch("https://api.morgen.so/v3/events/update", {
   }),
 });
 ```
+
+### Response
+
+Returns HTTP **200 OK** on success. The updated event is returned as the
+top-level response body.
+
+<Callout type="warning" emoji="⚠️">
+  Note the asymmetry: unlike `/events/create`, `/events/list` and
+  `GET /v3/events`, the update response is **not** wrapped in a `data` envelope.
+  The event is the response body itself.
+</Callout>
+
+```json
+{
+  "@type": "Event",
+  "id": "WyJhbmNvbmEubXJjQGdtYWlsLmNvbSI",
+  "calendarId": "WyJhbmNvbmEubXJjQGdtYWl",
+  "accountId": "640a62c9aa5b7e06cf420000",
+  "integrationId": "google",
+  "title": "Title updated",
+  "start": "2023-03-15T14:00:00",
+  "timeZone": "America/New_York",
+  "duration": "PT1H",
+  "showWithoutTime": false,
+  "privacy": "public",
+  "freeBusyStatus": "busy"
+}
+```
+
+The event has the same shape as the entries returned by `/events/list`, see
+[Event schema](#event-schema).
+
+<Callout type="info" emoji="💡">
+  When `seriesUpdateMode` is `all` or `future`, the update may act on the master
+  recurring event rather than the occurrence whose ID you sent, so the `id` in
+  the response is not necessarily the `id` you passed in. Read the `id` back from
+  the response rather than assuming it is unchanged.
+</Callout>
 
 ### Special cases
 
@@ -533,7 +715,7 @@ Please notice that once a room has been attached to an event it cannot be remove
 
 ## Delete an event
 
-The following endpoint can be used to update an event in a given calendar.
+The following endpoint can be used to delete an event from a given calendar.
 
 ```js
 fetch("https://api.morgen.so/v3/events/delete?seriesUpdateMode=<UPDATE_MODE>", {
@@ -546,12 +728,44 @@ fetch("https://api.morgen.so/v3/events/delete?seriesUpdateMode=<UPDATE_MODE>", {
 });
 ```
 
-| Parameter          | Type  | Default  | Required | Description                                                                                                                                                                                                                              |
-| :----------------- | :---- | :------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `seriesUpdateMode` | Query | `single` | No       | Defines how to update recurring events. Possible values are: `all` (update all events), `future` (update this and future occurrences), `single` (update this event only, default). This parameter has no effect on non-recurring events. |
-| `id`               | Body  | -        | Yes      | The ID of the event to update.                                                                                                                                                                                                           |
-| `accountId`        | Body  | -        | Yes      | The ID of the account the event belongs to.                                                                                                                                                                                              |
-| `calendarId`       | Body  | -        | Yes      | The ID of the calendar the event belongs to.                                                                                                                                                                                             |
+| Parameter          | Type  | Default  | Required | Description                                                                                                                                                                                                                       |
+| :----------------- | :---- | :------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `seriesUpdateMode` | Query | `single` | No       | Defines how to delete recurring events. Possible values are: `all` (delete the whole series), `future` (delete this and future occurrences), `single` (delete this occurrence only, default). |
+
+<Callout type="warning" emoji="⚠️">
+  **`seriesUpdateMode` is a query-string parameter only.** Putting it in the JSON
+  request body returns HTTP 400. The delete body accepts only the fields listed
+  below, and any property outside that set is rejected rather than ignored.
+</Callout>
+
+<Callout type="info" emoji="💡">
+  On a **non-recurring** event, only omitting `seriesUpdateMode` or sending
+  `single` is accepted. Sending `all` or `future` returns HTTP 400 with a message
+  such as "Cannot apply 'all' series update mode to non-recurring events".
+</Callout>
+
+### Request Body Fields
+
+| Field        | Type   | Required | Description                                                                           |
+| :----------- | :----- | :------- | :------------------------------------------------------------------------------------ |
+| `id`         | String | Yes      | The Morgen ID of the event to delete. See [Event IDs](#event-ids).                     |
+| `accountId`  | String | Yes      | The ID of the account the event belongs to.                                            |
+| `calendarId` | String | Yes      | The ID of the calendar the event belongs to.                                           |
+
+These three fields are sufficient. Sending any other property in the body returns
+HTTP 400.
+
+### Response
+
+Returns HTTP **204 No Content** on success, with an **empty response body**.
+
+<Callout type="warning" emoji="⚠️">
+  There is no JSON body on a successful delete. Clients that unconditionally
+  parse the response as JSON will fail on the empty payload, check for 204 first.
+  In particular, the response does not tell you which event was removed, so when
+  using `seriesUpdateMode=all` or `future` you cannot learn from the response
+  which occurrences were affected.
+</Callout>
 
 ## Common Validation Errors
 

--- a/content/rate-limits.mdx
+++ b/content/rate-limits.mdx
@@ -9,11 +9,11 @@ The Morgen API enforces rate limits to ensure fair usage and system stability. R
 
 | Authentication | Limit | Window |
 | :------------- | :---- | :----- |
-| API Key | 100 points | 15 minutes |
+| API Key | 300 points | 15 minutes |
 
 <JwtContent>
 
-| JWT Token | 300 requests | 15 minutes |
+| JWT Token | 500 points | 15 minutes |
 
 </JwtContent>
 
@@ -32,16 +32,16 @@ Every API response includes headers to help you track your rate limit usage. The
 
 | Header | Description |
 | :----- | :---------- |
-| `RateLimit-Limit` | Maximum points/requests allowed in the current window |
-| `RateLimit-Remaining` | Points/requests remaining in the current window |
+| `RateLimit-Limit` | Maximum points allowed in the current window |
+| `RateLimit-Remaining` | Points remaining in the current window |
 | `RateLimit-Reset` | Seconds until the rate limit window resets |
 | `Retry-After` | Seconds to wait before retrying (only present when `RateLimit-Remaining` is 0) |
 
 ### Example Headers
 
 ```
-RateLimit-Limit: 100
-RateLimit-Remaining: 90
+RateLimit-Limit: 300
+RateLimit-Remaining: 290
 RateLimit-Reset: 459
 ```
 

--- a/content/rate-limits.mdx
+++ b/content/rate-limits.mdx
@@ -15,6 +15,10 @@ The Morgen API enforces rate limits to ensure fair usage and system stability. R
 
 | JWT Token | 500 points | 15 minutes |
 
+Every endpoint costs a JWT caller 1 point, including `/list` endpoints. The
+per-endpoint costs in the next section apply to API Key authentication only, so
+a JWT budget of 500 points is effectively 500 requests.
+
 </JwtContent>
 
 ## Points System (API Key)

--- a/content/tasks.mdx
+++ b/content/tasks.mdx
@@ -25,8 +25,14 @@ fetch(
 
 | Parameter      | Type  | Default | Required | Description                                                     |
 | :------------- | :---- | :------ | :------- | :-------------------------------------------------------------- |
-| `limit`        | Query | 100     | No       | Maximum number of tasks to return (max 100).                    |
+| `limit`        | Query | 1       | No       | Maximum number of tasks to return (max 100).                    |
 | `updatedAfter` | Query | -       | No       | Only return tasks updated/created after this ISO 8601 datetime. |
+
+<Callout type="warning" emoji="⚠️">
+  **`limit` defaults to 1, not to the maximum.** Omitting it returns a single
+  task, which is easy to misread as an almost empty result. Always set it
+  explicitly.
+</Callout>
 
 <Callout type="warning" emoji="⚠️">
   The Tasks API is primarily designed for creating tasks in Morgen from
@@ -44,62 +50,35 @@ Here is an example response for the `/tasks/list` endpoint:
     "tasks": [
       {
         "@type": "Task",
-
-        // Morgen ID for task
         "id": "WyJBUU1rQURaa1lXWXpOel...",
-
-        // Morgen ID for the account
         "accountId": "640a62c9aa5b7e06cf420000",
-
         "integrationId": "morgen",
-
-        // Task list this task belongs to
         "taskListId": "default",
-
         "created": "2023-02-28T11:50:57",
         "updated": "2023-02-28T17:56:44",
-
         "title": "Review quarterly report",
         "description": "Review and provide feedback on Q4 report",
         "descriptionContentType": "text/plain",
-
-        // Due date in LocalDateTime format
         "due": "2023-03-15T17:00:00",
         "timeZone": "Europe/Berlin",
-
-        // Estimated time to complete (ISO 8601 duration)
         "estimatedDuration": "PT2H",
-
-        // Priority: 0 = undefined, 1 = highest, 9 = lowest
         "priority": 1,
-
-        // Task completion status
         "progress": "needs-action",
-
-        // Position within the task list (for ordering)
         "position": 0,
-
-        // Relations to other tasks (for subtasks)
         "relatedTo": {
           "parent-task-id": {
             "@type": "Relation",
             "relation": { "parent": true }
           }
         },
-
-        // Array of tag IDs assigned to this task
         "tags": ["550e8400-e29b-41d4-a716-446655440000"],
-
-        // Morgen-specific derived fields (read-only)
         "morgen.so:derived": {
           "scheduled": true
         }
       }
     ],
-    // Label definitions for task metadata
-    "labelDefs": [...],
-    // Spaces/workspaces the tasks belong to
-    "spaces": [...]
+    "labelDefs": [],
+    "spaces": []
   }
 }
 ```
@@ -126,6 +105,13 @@ Here is an example response for the `/tasks/list` endpoint:
 | `tags`                   | Array  | Array of tag IDs assigned to this task (see [Tags](/tags))                         |
 | `created`                | String | Creation timestamp (UTC)                                                           |
 | `updated`                | String | Last update timestamp (UTC)                                                        |
+| `links`                  | Object | Links attached to the task, keyed by link ID                                       |
+| `morgen.so:derived`      | Object | Read-only fields derived from the rest of the task, for example `scheduled`        |
+
+Alongside `tasks`, the response envelope carries two more arrays: `labelDefs`,
+the label definitions referenced by task metadata, and `spaces`, the workspaces
+the tasks belong to. Both are siblings of `tasks` under `data`, not fields on a
+task.
 
 <Callout type="warning" emoji="⚠️">
   Additional fields might be added in the future. If you are storing tasks in
@@ -158,13 +144,20 @@ fetch("https://api.morgen.so/v3/tasks?id=<TASK_ID>", {
     "task": {
       "@type": "Task",
       "id": "WyJBUU1rQURaa1lXWXpOel...",
+      "taskListId": "default",
       "title": "Review quarterly report",
-      ...
+      "progress": "needs-action",
+      "created": "2023-02-28T11:50:57",
+      "updated": "2023-02-28T17:56:44"
     },
-    "labelDefs": [...]
+    "labelDefs": []
   }
 }
 ```
+
+The `task` object has the same shape as an entry in `/tasks/list`, see [Task
+Fields Reference](#task-fields-reference). Fields with no value are omitted
+rather than returned as `null`, so the exact set of keys varies by task.
 
 ## Create a task
 
@@ -204,6 +197,10 @@ fetch("https://api.morgen.so/v3/tasks/create", {
 | `tags`                   | Array  | No       | Array of tag IDs to assign to the task (see [Tags](/tags)).                      |
 
 ### Response
+
+Returns HTTP 200 OK on success, with the ID of the new task. Note that this is
+`200`, not `201`, and that the created task is not echoed back. If you need the
+full object, follow up with [Get a task](#get-a-task).
 
 ```json
 {


### PR DESCRIPTION
Closes MOR-4652.

## Why

A paying developer opened [Intercom 215475376481934](https://app.intercom.com/a/inbox/kz0ui7gk/inbox/conversation/215475376481934) asking us to confirm the response contract for `POST /v3/events/create` and `POST /v3/events/delete`. Every question they asked mapped one-to-one onto something `events.mdx` omits.

They answered their own Tasks questions from the docs and could not answer a single Events question. `grep -c "204 No Content"` returns 5 for `tasks.mdx` and 0 for `events.mdx`. This is the sibling of MOR-3196, which delivered the Tasks reference in Dec 2025; the Events equivalent was never written.

## What changed

**`content/events.mdx`**
- `### Response` sections for list, get, create, update and delete: verified status code, body shape, pasteable JSON example.
- New `## Get an event` documenting `GET /v3/events?id=<id>`, previously undocumented, including that it costs 1 rate-limit point against list's 10.
- New `### Event IDs` covering the id contract: opaque, byte-identical round-trip, account-scoped, not interchangeable with `calendarId`, `uid` is not `id`, and different between create and list for recurring events. **The encoding itself is deliberately not published** so we keep the freedom to change it.
- New `## Errors` documenting both error body shapes plus a status table.
- `seriesUpdateMode` documented as query-string only on both update and delete. The bodies are validated with `whitelist + forbidNonWhitelisted`, so sending it in the body is a hard 400.
- Delete section de-copy-pasted. It previously said "can be used to **update** an event" and described `id` as "the ID of the event to **update**".
- List example replaced with parseable JSON. It carried `//` comments and bare `...`; the commentary moved into a new `### Event Fields Reference` table.

**`content/authentication.mdx`** — base URL, the `/v3` prefix, and `Authorization: ApiKey <KEY>` stated as a contract. Previously both had to be reverse-engineered from code samples.

**`content/rate-limits.mdx`** — corrected values that contradicted the source (see table below).

## Two findings worth calling out

**`POST /v3/events/update` does not return 204.** Our internal audit inferred that "by symmetry with delete". It actually returns **200 with the event as a bare top-level body**, no `data` envelope, unlike create/list/get. A single parser written for both endpoints breaks. Documented with an explicit asymmetry warning.

**The generic error shape is not a 5xx-only concern.** The discriminator is whether the error was thrown deliberately, not its status class. `express.json({limit: "2mb"})` is mounted ahead of the routes, so malformed JSON or an oversized payload is rejected before the endpoint, is not an `HttpException`, and returns **4xx with no `status` field in the body**. A client written as `if (body.status >= 400)` reads `undefined` and treats a failed request as successful. The warning callout says "not purely a 500 concern" for this reason.

## Verification

Every status code re-checked against `morgen-backend` source rather than copied from the audit.

| Documented | Verified at |
|---|---|
| `GET /v3/events?id=` → 200, `{"data":{"event":{…}}}` | `events.controller.ts:38`; test at `events.controller.integration.spec.ts:76` |
| `GET /v3/events/list` → 200, `{"data":{"events":[…]}}` | `events.controller.ts:66` |
| `POST /v3/events/create` → 200 (not 201), `{"data":{"event":{…}}}` | `events.controller.ts:97-101`; test at `:69` |
| `POST /v3/events/update` → 200, **bare event** | `events.controller.ts:127`; `events.v3.service.ts:125-130`; test at `:89` |
| `POST /v3/events/delete` → 204, empty | `events.controller.ts:153`; test at `:101` |
| `seriesUpdateMode` query-only; in body → 400 | `events.controller.ts:142`; `events.v3.route.ts:58,67`; `validation.middleware.ts:10-11` |
| `all`/`future` on non-recurring → 400 | `morgen-integration-service` `google/lib/adapter.ts:456-468` |
| Deliberate errors → `{message, status, context, errorRef}` | `error.middleware.ts:32-37` |
| Unexpected → `{message, errorRef}`, no `status` | `error.middleware.ts:38-47` |
| `controlledError` always true on `HttpException` | `HttpException.ts:33` |
| `errorRef` present in both shapes | `error.middleware.ts:19`, used at `:37` and `:45` |
| Null keys stripped, not nulled | `integrations/utils.ts:112-121` |
| Body-parser errors reach the generic branch | `app.ts:227,229` → `:294` → `:319` |
| Rate limits: API Key 300, JWT 500, window 15 min | `rateLimit.middleware.ts:20-23` |
| `/list` = 10 points, others = 1 | `rateLimit.middleware.ts:130` |

Rate limit corrections:

| Was published | Actual |
|---|---|
| API Key 100 points | **300** |
| JWT 300 **requests** | **500 points** (unit was also wrong) |
| Example `RateLimit-Limit: 100` | **300** |

`npx next build` passes. All 14 JSON blocks in `events.mdx` parse under `json.loads`.

## Not verified, hedged in the text

- Cross-account id reuse. Only the legacy-vs-sync split is confirmed to throw `Invalid id format`; same-family cross-account reuse is not. Wording states the constraint without promising a specific failure mode.
- Non-Google field sets. Enumerated from the Google bindings only; hedged as "the exact set of keys varies by provider".
- Which plans carry `zapier-integrations`. The 403 path is verified, the plan mapping is not, so the text says "if your plan does not include API access" rather than naming a tier.

## Out of scope

Task soft-delete semantics are deliberately excluded pending MOR-4653. `morgen-backend/openapi.yaml` (zero v3 paths, contradicts current behaviour) is untouched. Also left alone: the undocumented `fieldSet` param on `/events/list`, and a pre-existing list example showing `google.com:*` fields on an `o365` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API authentication guidance covering the base URL, versioned endpoints, API key syntax, request examples, and 401/403 responses.
  * Expanded event API documentation with validation rules, field references, opaque IDs, recurring-event behavior, retrieval, and detailed create, update, and delete response formats.
  * Documented shared error formats and request restrictions for event operations.
  * Updated rate limits to 300 points for API keys and 500 points for JWTs per 15 minutes, with consistent header examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->