### PR TITLE
docs(MOR-4652, MOR-4653): document 404 on event reads and the task deleted flag

### DIFF
--- a/content/events.mdx
+++ b/content/events.mdx
@@ -347,6 +347,58 @@ The event has the same shape as the entries returned by `/events/list`, see
   Limits](/rate-limits) for details.
 </Callout>
 
+### Deleted and unknown events
+
+An event that cannot be retrieved returns HTTP **404**. It does not return `200`
+with a null or empty `event`:
+
+```json
+{
+  "message": "Cancelled events cannot be retrieved from Google",
+  "status": 404,
+  "errorRef": "V1StGXR8Z5jd"
+}
+```
+
+The same `404` covers every case where the event is not there:
+
+- it was deleted, by you or from the calendar directly
+- it was cancelled at the provider
+- the ID never existed on this account
+
+The exact `message` varies by provider and by whether the provider still holds a
+cancelled copy, so treat it as diagnostic detail and branch on the status line.
+
+This endpoint reads the connected calendar directly rather than a copy held by
+Morgen, so the response reflects the provider's state at the moment you ask.
+
+<Callout type="info" emoji="💡">
+  **A `404` here means absence, not "try again later".** Transient conditions
+  surface as different codes: a provider outage returns `5xx`, a rate limit
+  returns `429`, and an expired or revoked calendar connection returns `401` or
+  `403`. None of them degrade into a `404`, so you do not need a retry loop to
+  distinguish a deleted event from a temporarily unreachable one.
+</Callout>
+
+#### Verifying that an event was deleted
+
+To confirm a deletion, read the event back by ID and assert on the pair:
+
+1. `POST /v3/events/delete` returns **204**.
+2. `GET /v3/events?id=<same id>` returns **404**.
+
+Both steps matter. The `204` is the success signal for the deletion itself. The
+`404` confirms the event is no longer retrievable, but on its own it does not
+tell you that *your* delete caused it, since an unknown ID and an
+already-cancelled event return the same status.
+
+<Callout type="warning" emoji="⚠️">
+  **Do not verify a deletion by absence from `/events/list`.** That endpoint
+  requires a `start` and `end` window and omits cancelled events, so a missing
+  event may have been deleted, or may simply fall outside your window or outside
+  the calendars you passed in `calendarIds`. Read back by ID instead.
+</Callout>
+
 ## Create an event
 
 Morgen offers an endpoint to create events in a given calendar.
@@ -770,6 +822,16 @@ Returns HTTP **204 No Content** on success, with an **empty response body**.
   which occurrences were affected.
 </Callout>
 
+<Callout type="warning" emoji="⚠️">
+  **Deleting is not idempotent.** Deleting an event that is already deleted
+  returns **404**, not another `204`. The endpoint reads the event before
+  removing it, and that read fails on an event the provider has already
+  cancelled. Cleanup code that may run twice, and retries of a delete that timed
+  out, should therefore treat a `404` from this endpoint as success: it means the
+  event is gone. Note that this differs from [deleting a
+  task](/tasks#delete-a-task), where a repeated delete returns `204` again.
+</Callout>
+
 ## Errors
 
 Errors are produced by a single shared handler, so the status codes and body
@@ -781,6 +843,7 @@ the Morgen API.
 | `400`  | The request failed validation: a missing or malformed field, an unknown property in the body or query string, or an ID that could not be resolved.           |
 | `401`  | The `Authorization` header is missing, malformed, or carries a key that is not valid. See [Authentication](/authentication).                                 |
 | `403`  | The key is valid but your plan does not include API access.                                                                                                  |
+| `404`  | The event could not be retrieved from the connected calendar: it was deleted or cancelled, or the ID never existed on this account. Returned by [Get an event](#get-an-event) and by a repeated [Delete](#delete-an-event). |
 | `429`  | You have exceeded your rate limit. See [Rate Limits](/rate-limits).                                                                                          |
 | `500`  | An unexpected server-side failure.                                                                                                                          |
 

--- a/content/tasks.mdx
+++ b/content/tasks.mdx
@@ -159,6 +159,61 @@ The `task` object has the same shape as an entry in `/tasks/list`, see [Task
 Fields Reference](#task-fields-reference). Fields with no value are omitted
 rather than returned as `null`, so the exact set of keys varies by task.
 
+### Deleted and unknown tasks
+
+This endpoint returns HTTP **200** in every case, including for a task that no
+longer exists. It never returns `404`. The three outcomes are distinguished by
+the body:
+
+| Case                              | Response                                                        |
+| :-------------------------------- | :-------------------------------------------------------------- |
+| The task exists                   | `200`, the task under `data.task`, with no `deleted` field       |
+| The task was deleted              | `200`, the task under `data.task`, with **`"deleted": true`**    |
+| The ID is unknown, or not yours   | `200`, `data.task` set to `null`                                 |
+
+```json
+{
+  "data": {
+    "task": {
+      "@type": "Task",
+      "id": "fb0ff56a-24f0-40d0-844a-14c6de79c576",
+      "title": "Review quarterly report",
+      "progress": "needs-action",
+      "deleted": true,
+      "integrationId": "morgen"
+    },
+    "labelDefs": []
+  }
+}
+```
+
+Deleting a task does not remove the record, so a deleted task stays readable
+indefinitely and keeps the field values it had, including its `progress`. The
+`deleted` flag is what marks it, and it is added alongside the existing fields
+rather than replacing them.
+
+#### Verifying that a task was deleted
+
+Read the task back by ID and check `deleted`:
+
+1. `POST /v3/tasks/delete` returns **204**.
+2. `GET /v3/tasks?id=<same id>` returns **200** with `"deleted": true`.
+
+<Callout type="warning" emoji="⚠️">
+  **Do not verify a deletion by a `404`, and do not verify it by absence from
+  `/tasks/list`.** This endpoint never returns `404`, so a check written that way
+  reports every successful deletion as a failure. Absence from `/tasks/list` does
+  not prove deletion either, since that endpoint returns only open tasks: a
+  merely completed task is missing too, as is anything past the `limit`.
+</Callout>
+
+<Callout type="info" emoji="💡">
+  Note the asymmetry with events, where deletion is applied at the connected
+  calendar rather than recorded on a Morgen document: there, a deleted event
+  returns `404` from [Get an event](/events#get-an-event). Tasks return `200` with
+  a flag, events return `404`.
+</Callout>
+
 ## Create a task
 
 Create a new task in Morgen.
@@ -300,7 +355,9 @@ Returns HTTP 204 No Content on success.
 
 ## Delete a task
 
-Delete a task permanently.
+Delete a task. The record is retained and marked as deleted rather than being
+removed, so the task remains readable by ID with a `deleted` flag. See [Deleted
+and unknown tasks](#deleted-and-unknown-tasks).
 
 ```js
 fetch("https://api.morgen.so/v3/tasks/delete", {
@@ -323,7 +380,14 @@ fetch("https://api.morgen.so/v3/tasks/delete", {
 
 ### Response
 
-Returns HTTP 204 No Content on success.
+Returns HTTP **204 No Content** on success, with an empty response body.
+
+<Callout type="info" emoji="💡">
+  **Deleting is idempotent.** Deleting a task that is already deleted returns
+  `204` again, so a repeated delete is not a way to test whether a task still
+  exists. An ID that never existed is rejected with `400 "Invalid task id"`,
+  not `404`. Deleting a parent task also deletes its subtasks.
+</Callout>
 
 ## Close a task
 


### PR DESCRIPTION
## Why

Intercom [215475376481934](https://app.intercom.com/a/inbox/kz0ui7gk/inbox/conversation/215475376481934). A developer building a strictly bounded create → read-back → delete lifecycle against the public v3 API ran it end to end, got a `404` on the read-back after a successful `204` delete, and stopped, because nothing on the Events page defines `404` as a supported response. He was right to stop.

Both pages were missing the post-delete read contract, in opposite directions.

## Events

The exact-ID GET reads the connected calendar directly rather than a Morgen copy, so a deleted or cancelled event returns `404`. The Errors table listed `400/401/403/429/500` and omitted `404` entirely.

- Adds the `404` row to the Errors table.
- New **Deleted and unknown events** section: the status, its three causes (deleted, cancelled at the provider, never existed), and that the read is live.
- Callout that transient conditions never degrade into `404` — a provider outage is `5xx`, a rate limit `429`, a broken connection `401`/`403` — so `404` means absence and needs no retry loop.
- New **Verifying that an event was deleted**: assert on the `204`-then-`404` pair, since a `404` alone proves absence but not authorship.
- Warning against verifying by absence from `/events/list`, which requires a `start`/`end` window and filters cancelled events, so a miss is ambiguous three ways.
- **Deleting is not idempotent**: the endpoint reads the event before removing it, so a repeat delete returns `404`, not another `204`. Cross-linked to tasks, where the same call returns `204`.

## Tasks

Deletion is a soft delete, so **"Delete a task permanently" was wrong**. Worse, the `deleted` flag shipped in morgen-so/morgen-backend#987 was documented nowhere, despite being the supported way to confirm a deletion — MOR-4653 deliberately deferred the wording until the behaviour was decided, and the docs never caught up after it shipped. A caller had no described path to verify a deletion at all.

- Rewrites the delete description to say the record is retained and marked.
- New **Deleted and unknown tasks** section with the three outcomes of a read by id (live / deleted / unknown) and an example body carrying `"deleted": true`.
- New **Verifying that a task was deleted**, plus a warning against both wrong approaches: this endpoint never returns `404`, and absence from `/tasks/list` does not prove deletion since that endpoint returns only open tasks.
- Records that a repeat delete returns `204`, an unknown id returns `400 "Invalid task id"` rather than `404`, and a parent delete cascades to subtasks.
- Callout on the events-vs-tasks asymmetry, since a developer using both will hit it.

## Verification

Run against a live account on a throwaway Google calendar, both records cleaned up:

| Call | Status | Result |
|---|---|---|
| `POST /v3/events/create` | 200 | id at `data.event.id` |
| `GET /v3/events?id=` (alive) | 200 | full event |
| `POST /v3/events/delete` | 204 | empty |
| `GET /v3/events?id=` (deleted) | **404** | `Cancelled events cannot be retrieved from Google` |
| `POST /v3/events/delete` (repeat) | **404** | not 204 |
| `POST /v3/tasks/create` | 200 | `{"data":{"id":"…"}}` |
| `POST /v3/tasks/delete` | 204 | empty |
| `GET /v3/tasks?id=` (deleted) | **200** | full task **plus `"deleted": true`** |

The event `404` fired the deliberate branch (`integrations/google/lib/adapter.ts:331-338`, Morgen rejects a provider tombstone and raises the 404 itself with `skipSentry`), not the provider-purge branch, so the guarantee does not depend on Google's retention behaviour.

`npm run build` passes.

Full investigation: `data/investigations/215475376481934/` in the tech-support repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified event retrieval behavior for missing, deleted, and cancelled events, including status codes and provider-specific errors.
  * Added event deletion verification guidance, including repeated deletion behavior.
  * Documented task deletion behavior, including retained deleted records, deletion status flags, idempotency, invalid IDs, and cascading subtask deletion.
  * Expanded task retrieval and deletion response examples for existing, deleted, and unknown task IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->